### PR TITLE
Add description to GitHub Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ LABEL "com.github.actions.icon"="globe"
 LABEL "com.github.actions.color"="green"
 
 LABEL "repository"="http://github.com/BryanSchuetz/jekyll-deploy-gh-pages"
-LABEL "homepage"="http://github.com/BryanSchuetz/jekyll-deploy-gh-pages"
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@ ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
+LABEL "com.github.actions.name"="Build & Deploy to GitHub Pages"
+LABEL "com.github.actions.description"="Builds & deploys the project to GitHub Pages"
+LABEL "com.github.actions.icon"="globe"
+LABEL "com.github.actions.color"="green"
+
+LABEL "repository"="http://github.com/BryanSchuetz/jekyll-deploy-gh-pages"
+LABEL "homepage"="http://github.com/BryanSchuetz/jekyll-deploy-gh-pages"
+
 ADD entrypoint.sh /entrypoint.sh
 
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,13 @@ ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
+LABEL "com.github.actions.name"="Builds to GitHub Pages"
+LABEL "com.github.actions.description"="Builds the project to GitHub Pages"
+LABEL "com.github.actions.icon"="globe"
+LABEL "com.github.actions.color"="green"
+
+LABEL "repository"="http://github.com/BryanSchuetz/jekyll-deploy-gh-pages/tree/master/build"
+
 ADD entrypoint.sh /entrypoint.sh
 
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,2 +1,9 @@
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+LABEL "com.github.actions.name"="Deploys to GitHub Pages"
+LABEL "com.github.actions.description"="Deploys the project to GitHub Pages"
+LABEL "com.github.actions.icon"="globe"
+LABEL "com.github.actions.color"="green"
+
+LABEL "repository"="http://github.com/BryanSchuetz/jekyll-deploy-gh-pages/tree/master/deploy"


### PR DESCRIPTION
This PR adds an actual description to all of the GitHub Actions.

See https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#label for more info.

EDIT: Can't seem to figure out why the description still doesn't show on my private repository. Will have to check again later.