### PR TITLE
Allow the ability to specify a custom branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A GitHub Action for building and deploying a Jekyll repo back to its `gh-pages` 
 ## Environment Variables
 * `GITHUB_ACTOR`: Username of repo owner or object intiating the action (GitHub Provides)
 * `GITHUB_REPO`: Owner/Repository (GitHub Provides)
-* `BRANCH`: The branch to deploy to
+* `BRANCH`: The branch to deploy to (Default: `gh-pages`)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A GitHub Action for building and deploying a Jekyll repo back to its `gh-pages` 
 ## Environment Variables
 * `GITHUB_ACTOR`: Username of repo owner or object intiating the action (GitHub Provides)
 * `GITHUB_REPO`: Owner/Repository (GitHub Provides)
+* `BRANCH`: The branch to deploy to
 
 ## Examples
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,6 +8,7 @@ We're only deploying the site here. Site files should be sitting in `build` havi
 ## Environment Variables
 * `GITHUB_ACTOR`: Username of repo owner or object intiating the action (GitHub Provides)
 * `GITHUB_REPO`: Owner/Repository (GitHub Provides)
+* `BRANCH`: The branch to deploy to
 
 ## Examples
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,7 +8,7 @@ We're only deploying the site here. Site files should be sitting in `build` havi
 ## Environment Variables
 * `GITHUB_ACTOR`: Username of repo owner or object intiating the action (GitHub Provides)
 * `GITHUB_REPO`: Owner/Repository (GitHub Provides)
-* `BRANCH`: The branch to deploy to
+* `BRANCH`: The branch to deploy to (Default: `gh-pages`)
 
 ## Examples
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd build
 remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
-remote_branch="gh-pages" && \
+remote_branch="${BRANCH:gh-pages}" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ bundle exec jekyll build
 echo '👍 THE SITE IS BUILT—PUSHING IT BACK TO GITHUB-PAGES'
 cd build
 remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
-remote_branch="gh-pages" && \
+remote_branch="${BRANCH}:gh-pages" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ bundle exec jekyll build
 echo '👍 THE SITE IS BUILT—PUSHING IT BACK TO GITHUB-PAGES'
 cd build
 remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
-remote_branch="${BRANCH}:gh-pages" && \
+remote_branch="${BRANCH:gh-pages}" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \


### PR DESCRIPTION
This PR adds the ability to specify a custom branch, as some people may want to deploy to the `master` branch on a user repository.