### PR TITLE
Disable jekyll build by GitHub

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ echo '👍 BUNDLE INSTALLED—BUILDING THE SITE'
 bundle exec jekyll build
 echo '👍 THE SITE IS BUILT—PUSHING IT BACK TO GITHUB-PAGES'
 cd build
+touch .nojekyll
 remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
 remote_branch="gh-pages" && \
 git init && \


### PR DESCRIPTION
I sometimes get the output "Your site is having problems building: Page build failed."

![grafik](https://user-images.githubusercontent.com/1366654/66085739-5a911200-e572-11e9-91d9-e4cbdaee7c27.png)

According to https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/, a `.nojekyll` file could help.