### PR TITLE
Fix typo and lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 
 # A GitHub Action for Custom Jekyll Builds on GitHub Pages
 
-A GitHub Action for building and deploying a Jekyll repo back to its `gh-pages` branch. 
+A GitHub Action for building and deploying a Jekyll repo back to its `gh-pages` branch.
 
 **Why not just let GitHub Pages build it? Becaues this way we can use our own custom Jekyll plugins and build scripts.**
 
 ## Secrets
+
 * `GITHUB_TOKEN`: Access key scoped to the repository, we need this to push the site files back to the repo. (specify in workflow)
   
 ## Environment Variables
+
 * `GITHUB_ACTOR`: Username of repo owner or object intiating the action (GitHub Provides)
 * `GITHUB_REPO`: Owner/Repository (GitHub Provides)
 
@@ -21,13 +23,13 @@ name: Jekyll Deploy
 
 on: [push]
 
-jobs: 
+jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Build & Deploy to GitHub Pages
-        env: 
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
           GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
@@ -39,7 +41,7 @@ Clones the repo, builds the site, and commits it back to the gh-pages branch of 
 ## Caveats
 
 * This uses the v2 of the Actions beta—note the Yaml based workflow syntax.
-* **`GITHUB_TOKEN`, privilages are still being sorted out by the Actions/GH-Pages team. Changes pushed to your GH-pages branch will only be picked up by the Github Pages server if your workflow is in a private repository.**
+* **`GITHUB_TOKEN`, privileges are still being sorted out by the Actions/GH-Pages team. Changes pushed to your GH-pages branch will only be picked up by the Github Pages server if your workflow is in a private repository.**
 * Needs a .gemfile
 * `destination:` should be set to `./build` in your _config.yml file—as God demands.
 * Be sure that any custom gems needed are included in your Gemfile.


### PR DESCRIPTION
Fixes typo ("privileges") and fixes simple [markdown-lint](https://github.com/DavidAnson/markdownlint) rules.