### PR TITLE
Exit script with code when failing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -e
+
 echo '👍 ENTRYPOINT HAS STARTED—INSTALLING THE GEM BUNDLE'
 bundle install
 bundle list | grep "jekyll ("


### PR DESCRIPTION
Github Action needs to know when there is an error in `entrypoint.sh` to mark the build with a big fat ❌ 