### PR TITLE
Eliminate the need of mandatory destination config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,4 @@ Clones the repo, builds the site, and commits it back to the gh-pages branch of 
 * This uses the v2 of the Actions beta—note the Yaml based workflow syntax—you must have access to the beta release of actions.
 * **`GITHUB_TOKEN`, privileges are still being sorted out by the Actions/GH-Pages team. Changes pushed to your GH-pages branch will only be picked up by the Github Pages server if your workflow is in a private repository.**
 * Needs a .gemfile
-* `destination:` should be set to `./build` in your _config.yml file—as God demands.
 * Be sure that any custom gems needed are included in your Gemfile.

--- a/build/README.md
+++ b/build/README.md
@@ -25,5 +25,4 @@ Clones the repo and builds the site—that's it.
 ## Caveats
 
 * Needs a .gemfile
-* `destination:` should be set to `./build` in your _config.yml file—as God demands.
 * Be sure that any custom gems needed are included in your Gemfile.

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -3,6 +3,6 @@ echo '👍 ENTRYPOINT HAS STARTED—INSTALLING THE GEM BUNDLE'
 bundle install > /dev/null 2>&1
 bundle list | grep "jekyll ("
 echo '👍 BUNDLE INSTALLED—BUILDING THE SITE'
-bundle exec jekyll build
+bundle exec jekyll build -d ./build
 echo '👍 THE SITE IS BUILT—GREAT SUCCESS'
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,5 +28,4 @@ Grabs the site files in `build` and commits them to the gh-pages branch of the s
 
 ## Caveats
 
-* `destination:` should have beeen set to `./build` in your _config.yml file—as God demands.
 * Remember when adding this action to a workflow that will also use a build action, you need to define that action in the `needs` paramater.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ echo '👍 ENTRYPOINT HAS STARTED—INSTALLING THE GEM BUNDLE'
 bundle install
 bundle list | grep "jekyll ("
 echo '👍 BUNDLE INSTALLED—BUILDING THE SITE'
-bundle exec jekyll build
+bundle exec jekyll build -d ./build
 echo '👍 THE SITE IS BUILT—PUSHING IT BACK TO GITHUB-PAGES'
 cd build
 remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \


### PR DESCRIPTION
Forcing users to change their config files to get it working with this action is not a good out-of-the-box experience and might come in the way to their other workflow steps. It would have been better if this action would have followed the default Jekyll behavior and used `_site` folder instead while giving an option for users to let the action know if they have customized the destination folder. However, this action seems to be forcing the decision the other way by asking users to change their config according to the hard coded setup of this action.

In this PR I have taken an intermediary approach which does not give users the option to tell their configured destination folder, but does not ask them to change that either. I have not tested these changes yet, but I am assuming that Jekyll would give command line arguments precedence over corresponding config file entry, if present.