### PR TITLE
Remove silent failures, abort on failure at each step

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
+
+set -e
+
 echo '👍 ENTRYPOINT HAS STARTED—INSTALLING THE GEM BUNDLE'
-bundle install > /dev/null 2>&1
+bundle install
 bundle list | grep "jekyll ("
 echo '👍 BUNDLE INSTALLED—BUILDING THE SITE'
 bundle exec jekyll build

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
+
+set -e
+
 cd build
-remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
-remote_branch="gh-pages" && \
-git init && \
-git config user.name "${GITHUB_ACTOR}" && \
-git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
-git add . && \
-echo -n 'Files to Commit:' && ls -l | wc -l && \
-git commit -m'action build' > /dev/null 2>&1 && \
-git push --force $remote_repo master:$remote_branch > /dev/null 2>&1 && \
-rm -fr .git && \
+remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+remote_branch="gh-pages"
+git init
+git config user.name "${GITHUB_ACTOR}"
+git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+git add .
+echo -n 'Files to Commit:' && ls -l | wc -l
+git commit -m'action build' > /dev/null
+git push --force $remote_repo master:$remote_branch > /dev/null
+rm -fr .git
 cd ../
 echo '👍 GREAT SUCCESS!'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,15 +9,15 @@ echo '👍 BUNDLE INSTALLED—BUILDING THE SITE'
 bundle exec jekyll build
 echo '👍 THE SITE IS BUILT—PUSHING IT BACK TO GITHUB-PAGES'
 cd build
-remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
-remote_branch="gh-pages" && \
-git init && \
-git config user.name "${GITHUB_ACTOR}" && \
-git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
-git add . && \
-echo -n 'Files to Commit:' && ls -l | wc -l && \
-git commit -m'action build' > /dev/null 2>&1 && \
-git push --force $remote_repo master:$remote_branch > /dev/null 2>&1 && \
-rm -fr .git && \
+remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+remote_branch="gh-pages"
+git init
+git config user.name "${GITHUB_ACTOR}"
+git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+git add .
+echo -n 'Files to Commit:' && ls -l | wc -l
+git commit -m'action build' > /dev/null
+git push --force $remote_repo master:$remote_branch > /dev/null
+rm -fr .git
 cd ../
 echo '👍 GREAT SUCCESS!'


### PR DESCRIPTION
Closes #21

Uses `set -e` in root, build, and deploy entrypoints to abort
on failure at each step, and removed the `&&` chaining. Also
Remove some of the stderr pipes to `/dev/null` for certain steps
because seeing these errors is important for debugging.