### PR TITLE
Docs clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 A GitHub Action for building and deploying a Jekyll repo back to its `gh-pages` branch. 
 
-**Why not just let GitHub Pages build it? Becaues this way we can use our own custom Jekyll plugins and build scripts.**
+**Why not just let GitHub Pages build it? Because this way we can use our own custom Jekyll plugins and build scripts.**
 
 ## Secrets
-* `GITHUB_TOKEN`: Access key scoped to the repository, we need this to push the site files back to the repo. (specify in workflow)
+* `GITHUB_TOKEN`: An access key which scoped to the repository - we need this to push the built site files back to the repo. This is generated for you on each workflow run - see usage in [example](#example). (GitHub Provides)
   
 ## Environment Variables
-* `GITHUB_ACTOR`: Username of repo owner or object intiating the action (GitHub Provides)
+* `GITHUB_ACTOR`: Username of repo owner or object initiating the action (GitHub Provides)
 * `GITHUB_REPO`: Owner/Repository (GitHub Provides)
 
 ## Example
@@ -34,11 +34,9 @@ jobs:
         uses: BryanSchuetz/jekyll-deploy-gh-pages@master
 ```
 
-Clones the repo, builds the site, and commits it back to the gh-pages branch of the repository. That's it. Just add the above example to a `main.yml` file in the `.github/workflows` directory of your repository—see caveats below. 
+Clones the repo, builds the site, and commits it back to the `gh-pages` branch of the repository. That's it. Just add the above example to a `main.yml` file in the `.github/workflows` directory of your repository — see caveats below. 
 
 ## Caveats
 
-* This uses the v2 of the Actions beta—note the Yaml based workflow syntax—you must have access to the beta release of actions.
-* Needs a .gemfile
-* `destination:` should be set to `./build` in your _config.yml file—as God demands.
-* Be sure that any custom gems needed are included in your Gemfile.
+* `destination:` should be set to `./build` in your `_config.yml` file — as God demands.
+* A `Gemfile` is required. This must include `jekyll` and any other custom gems.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A GitHub Action for building and deploying a Jekyll repo back to its `gh-pages` 
 **Why not just let GitHub Pages build it? Because this way we can use our own custom Jekyll plugins and build scripts.**
 
 ## Secrets
-* `GITHUB_TOKEN`: An access key which scoped to the repository - we need this to push the built site files back to the repo. This is generated for you on each workflow run - see usage in [example](#example). (GitHub Provides)
+* `GITHUB_TOKEN`: An access key which scoped to the repository - we need this to push the built site files back to the repo. This is generated for you on each workflow run——see usage in [example](#example). (GitHub Provides)
   
 ## Environment Variables
 * `GITHUB_ACTOR`: Username of repo owner or object initiating the action (GitHub Provides)
@@ -34,9 +34,9 @@ jobs:
         uses: BryanSchuetz/jekyll-deploy-gh-pages@master
 ```
 
-Clones the repo, builds the site, and commits it back to the `gh-pages` branch of the repository. That's it. Just add the above example to a `main.yml` file in the `.github/workflows` directory of your repository — see caveats below. 
+Clones the repo, builds the site, and commits it back to the `gh-pages` branch of the repository. That's it. Just add the above example to a `main.yml` file in the `.github/workflows` directory of your repository—see caveats below. 
 
 ## Caveats
 
-* `destination:` should be set to `./build` in your `_config.yml` file — as God demands.
+* `destination:` should be set to `./build` in your `_config.yml` file—as God demands.
 * A `Gemfile` is required. This must include `jekyll` and any other custom gems.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Clones the repo, builds the site, and commits it back to the gh-pages branch of 
 ## Caveats
 
 * This uses the v2 of the Actions beta—note the Yaml based workflow syntax—you must have access to the beta release of actions.
-* **`GITHUB_TOKEN`, privileges are still being sorted out by the Actions/GH-Pages team. Changes pushed to your GH-pages branch will only be picked up by the Github Pages server if your workflow is in a private repository.**
 * Needs a .gemfile
 * `destination:` should be set to `./build` in your _config.yml file—as God demands.
 * Be sure that any custom gems needed are included in your Gemfile.


### PR DESCRIPTION
The main reason for this PR is to remove the out of date GITHUB_TOKEN warning - this works fine now for public repo builds. I use it for a few.

The YAML beta note is also out of date as YAML is new standard.

I also cleaned up spacing, typos and made things easier to follow.